### PR TITLE
Correct the calculation of same in winklermod

### DIFF
--- a/stringcmp.py
+++ b/stringcmp.py
@@ -500,12 +500,11 @@ def winklermod(str1, str2, in_weight):
   #
   minlen = min(len(str1), len(str2))
 
-  for same in range(1,minlen+1):
-    if (str1[:same] != str2[:same]):
+  for same in range(min(minlen, 4)):
+    if str1[same] != str2[same]:
       break
-  same -= 1
-  if (same > 4):
-    same = 4
+  else:
+    same += 1
 
   assert (same >= 0)
 


### PR DESCRIPTION
The value of same is not calculated correctly when one string fully matches the leading characters of the other string and is shorter than four characters.  The proposed change fixes the calculation of same for that case.  Please see the notebook at http://nbviewer.ipython.org/github/machinelearningdeveloper/same-demo/blob/master/same_demo.ipynb to see a demonstration of the problem and its solution.